### PR TITLE
docs: API reference navigation and crosslinks

### DIFF
--- a/docs/src/content/docs/reference/api-reference.md
+++ b/docs/src/content/docs/reference/api-reference.md
@@ -2,6 +2,10 @@
 
 > ⚠️ **Experimental** — Squad is alpha software. APIs, commands, and behavior may change between releases.
 
+> 🔀 **This page has been superseded.** The auto-generated [TypeDoc API reference](api/index.md) covers all 395+ public exports with complete type signatures. The curated [SDK Guide](sdk.md) provides an overview with examples.
+
+> 💡 **Looking for the full auto-generated reference?** See the [TypeDoc API reference](api/index.md) — generated directly from the SDK TypeScript source with complete type signatures for all 395+ public exports.
+
 Complete reference for all public exports from `@bradygaster/squad-sdk`. Each section includes types, functions, and usage examples.
 
 ## Overview

--- a/docs/src/content/docs/reference/sdk.md
+++ b/docs/src/content/docs/reference/sdk.md
@@ -2,6 +2,7 @@
 
 > ⚠️ **Experimental** — Squad is alpha software. APIs, commands, and behavior may change between releases.
 
+> 💡 For the complete auto-generated API reference with full type signatures for all 395+ exports, see [API Reference](/squad/docs/reference/api/).
 
 Complete reference for `@bradygaster/squad-sdk` — the programmatic API for Squad.
 

--- a/docs/src/navigation.ts
+++ b/docs/src/navigation.ts
@@ -81,8 +81,8 @@ export const NAV_SECTIONS: NavSection[] = [
     dir: 'reference',
     items: [
       { title: 'CLI', slug: 'reference/cli' },
-      { title: 'SDK', slug: 'reference/sdk' },
-      { title: 'SDK API Reference', slug: 'reference/api-reference' },
+      { title: 'SDK Guide', slug: 'reference/sdk' },
+      { title: 'API Reference (TypeDoc)', slug: 'reference/api/index' },
       { title: 'SDK Integration', slug: 'reference/integration' },
       { title: 'Tools & Hooks', slug: 'reference/tools-and-hooks' },
       { title: 'Config', slug: 'reference/config' },


### PR DESCRIPTION
## Summary

Follow-up to #11 (TypeDoc build pipeline). Adds navigation and content crosslinks for the auto-generated API reference.

### Changes

- **Sidebar navigation:** Rename 'SDK' → 'SDK Guide', update 'API Reference (TypeDoc)' to point to generated `api/index`
- **api-reference.md:** Add superseded notice directing users to the TypeDoc API reference
- **sdk.md:** Add crosslink to the auto-generated API reference

### Dependencies

This PR depends on #11 being merged first (the generated `api/` directory must exist at build time for navigation links to resolve).

### Checklist

- [x] Navigation links point to correct generated paths
- [x] Crosslinks use relative paths where possible
- [x] No generated files committed