### PR TITLE
docs: clarify nap vs /compact distinction

### DIFF
--- a/docs/src/content/docs/concepts/nap-vs-compact.md
+++ b/docs/src/content/docs/concepts/nap-vs-compact.md
@@ -1,0 +1,52 @@
+---
+title: Nap vs /compact
+description: How Squad nap and Copilot CLI /compact solve different memory problems at different layers.
+---
+
+# Nap vs /compact
+
+Users hit memory limits in two ways: the chat gets too big, or agent memory piles up over time.
+
+The pain shows up for users as slow agents, lost context, or token pressure — even though the fixes happen behind the scenes.
+
+## How each one works
+
+**Squad Nap** fixes a long-term team problem by archiving shared memory to disk. Nothing is lost, and future agents stay lean.
+
+**/compact** fixes a right-now chat problem by summarizing and freeing tokens. Original messages are gone.
+
+## Comparison
+
+| | Squad Nap | /compact |
+|---|---|---|
+| Purpose | Archive squad memory | Shrink current chat |
+| Scope | Persistent, shared | Ephemeral, session-only |
+| Method | Move full data to disk | Replace with summary |
+| Logic | Size + age rules | One-pass LLM |
+| Trigger | Thresholds hit | User or token pressure |
+| Benefit | Future agents | Current conversation |
+| Recovery | Full (archives exist) | None |
+| Model | Filing cabinet | Whiteboard erase |
+
+## When to use each
+
+**Use `squad nap` when:**
+- Your `.squad/` files are growing and agents feel slower
+- You've completed a phase and want to archive old work
+- You're preparing to spawn new agents (smaller state = cheaper spawns)
+- You want to keep a permanent archive of past decisions (they go to `-archive.md`)
+
+**Use `/compact` when:**
+- Your current conversation is getting long and token-heavy
+- You want to continue the session but free up context space for new questions
+- You're running out of conversation tokens within a single session
+- You want a summary of your chat history before moving on
+
+## Using both together
+
+They're **not** mutually exclusive — use both in sequence for optimal team hygiene:
+
+1. **In your Squad session:** Tell the team to `take a nap`. This cleans up persistent state files, making future agent spawns lighter and faster.
+2. **After the session:** If your conversation was long, use `/compact` in the CLI to summarize the transcript. This frees tokens for the next session.
+
+**Bottom line: /compact helps this conversation. Squad Nap helps every conversation after this.**

--- a/docs/src/content/docs/features/context-hygiene.md
+++ b/docs/src/content/docs/features/context-hygiene.md
@@ -24,7 +24,7 @@ Over multiple sessions, Squad's `.squad/` files grow — agent histories, decisi
 
 ## Nap
 
-**What it does:** Summarizes accumulated work into smaller, more efficient memory files. This is the same as running `/compact` in the CLI or `squad nap` from the command line.
+**What it does:** Summarizes accumulated work in `.squad/` team state files into smaller, more efficient memory files. This compresses your persistent team knowledge — agent histories, decisions, and logs across multiple sessions.
 
 When you tell the team to "take a nap," each agent:
 
@@ -52,7 +52,7 @@ squad nap --deep       # Thorough cleanup with recursive descent
 squad nap --dry-run    # Preview what would be cleaned up
 ```
 
-In the interactive shell, use `/compact` for the same effect.
+> **Note:** For session-level conversation compression, use `/compact` in the Copilot CLI interactive shell. See [Nap vs /compact](/concepts/nap-vs-compact) for the difference between team state cleanup and session transcript compression.
 
 ---
 

--- a/docs/src/navigation.ts
+++ b/docs/src/navigation.ts
@@ -46,6 +46,8 @@ export const NAV_SECTIONS: NavSection[] = [
       { title: 'Response Modes', slug: 'features/response-modes' },
       { title: 'Parallel Execution', slug: 'features/parallel-execution' },
       { title: 'Memory', slug: 'features/memory' },
+      { title: 'Context Hygiene', slug: 'features/context-hygiene' },
+
       { title: 'Skills', slug: 'features/skills' },
       { title: 'Directives', slug: 'features/directives' },
       { title: 'Ceremonies', slug: 'features/ceremonies' },
@@ -129,6 +131,7 @@ export const NAV_SECTIONS: NavSection[] = [
       { title: 'Architecture', slug: 'concepts/architecture' },
       { title: 'Your Team', slug: 'concepts/your-team' },
       { title: 'Memory & Knowledge', slug: 'concepts/memory-and-knowledge' },
+      { title: 'Nap vs /compact', slug: 'concepts/nap-vs-compact' },
       { title: 'Parallel Work', slug: 'concepts/parallel-work' },
       { title: 'GitHub Workflow', slug: 'concepts/github-workflow' },
       { title: 'Portability', slug: 'concepts/portability' },

--- a/test/docs-build.test.ts
+++ b/test/docs-build.test.ts
@@ -53,6 +53,7 @@ const EXPECTED_FEATURES = [
   'ceremonies',
   'capability-routing',
   'consult-mode',
+  'context-hygiene',
   'copilot-coding-agent',
   'directives',
   'enterprise-platforms',
@@ -67,6 +68,7 @@ const EXPECTED_FEATURES = [
   'mcp',
   'memory',
   'model-selection',
+
   'notifications',
   'parallel-execution',
   'plugins',
@@ -87,7 +89,7 @@ const EXPECTED_FEATURES = [
   'worktrees',
 ];
 
-const EXPECTED_CONCEPTS = ['architecture', 'your-team', 'memory-and-knowledge', 'parallel-work', 'github-workflow', 'portability'];
+const EXPECTED_CONCEPTS = ['architecture', 'your-team', 'memory-and-knowledge', 'nap-vs-compact', 'parallel-work', 'github-workflow', 'portability'];
 
 // Blog posts are discovered dynamically to avoid breaking tests when posts change
 const EXPECTED_BLOG = existsSync(BLOG_CONTENT_DIR)


### PR DESCRIPTION
## Problem
The context-hygiene docs incorrectly state that Squad nap and Copilot CLI /compact are the same thing. They are fundamentally different:
- **Nap** compresses persistent .squad/ team state files (histories, decisions, logs)
- **/compact** summarizes the ephemeral conversation transcript in the current session

## Changes
- Fixed two incorrect equivalence claims in context-hygiene.md
- Added new comparison page: nap-vs-compact.md
- Updated navigation and test assertions

## Review requested
Flight (architecture), FIDO (quality)