### PR TITLE
fix(sdk): sync squad.agent.md roster when agents added to team.md

### DIFF
--- a/.changeset/fix-sdk-roster-sync.md
+++ b/.changeset/fix-sdk-roster-sync.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-sdk": patch
+"@bradygaster/squad-cli": patch
+---
+
+fix(sdk): sync squad.agent.md roster when agents added to team.md

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -25,6 +25,10 @@ Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos m
 - **Yes, but `## Members` has zero roster entries** → Init Mode (treat as unconfigured — scaffold exists but no team was cast)
 - **Yes, with roster entries** → Team Mode
 
+<!-- SQUAD:ROSTER_START -->
+_Roster will be populated when the team is cast._
+<!-- SQUAD:ROSTER_END -->
+
 ---
 
 ## Init Mode — Phase 1: Propose the Team

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Roster sync** (#83) — sync squad.agent.md roster when agents are added to team.md
+
 ### Added — Full Work Monitor for squad watch (#708)
 - `--execute` flag spawns Copilot sessions to work on actionable issues autonomously
 - Multi-platform support — auto-detects GitHub vs Azure DevOps from git remote URL

--- a/packages/squad-cli/src/cli/core/cast.ts
+++ b/packages/squad-cli/src/cli/core/cast.ts
@@ -11,6 +11,10 @@ import {
   addAgentToConfig,
 } from '@bradygaster/squad-sdk';
 import {
+  syncRosterToAgentDoc,
+  type RosterMember,
+} from '@bradygaster/squad-sdk/config';
+import {
   CastingEngine,
   type CastMember as EngineCastMember,
   type AgentRole as EngineAgentRole,
@@ -642,6 +646,19 @@ export async function createTeam(teamRoot: string, proposal: CastProposal): Prom
   // Sync new agents into squad.config.ts (if present)
   for (const member of allMembers) {
     await addAgentToConfig(teamRoot, member.name.toLowerCase(), member.role);
+  }
+
+  // Sync roster into .github/agents/squad.agent.md (#83)
+  const agentMdPath = join(teamRoot, '.github', 'agents', 'squad.agent.md');
+  if (storage.existsSync(agentMdPath)) {
+    const agentMdContent = await storage.read(agentMdPath) ?? '';
+    const rosterMembers: RosterMember[] = allMembers.map((m) => ({
+      name: m.name,
+      role: m.role,
+    }));
+    const updated = syncRosterToAgentDoc(agentMdContent, rosterMembers);
+    await storage.write(agentMdPath, updated);
+    filesCreated.push(agentMdPath);
   }
 
   return { teamRoot, membersCreated, filesCreated };

--- a/packages/squad-sdk/src/config/doc-sync.ts
+++ b/packages/squad-sdk/src/config/doc-sync.ts
@@ -5,12 +5,124 @@
  * The .agent.md file is the *reference* document; SquadConfig is the
  * *runtime* source of truth.  This module bridges the two.
  *
+ * Also handles team roster synchronisation — ensuring the roster embedded
+ * in squad.agent.md stays in sync with .squad/team.md (see #83).
+ *
  * @module config/doc-sync
  */
 
 import type { AgentDocMetadata } from './agent-doc.js';
 import type { SquadConfig, AgentConfig } from './schema.js';
 import { normalizeEol } from '../utils/normalize-eol.js';
+
+// ---------------------------------------------------------------------------
+// Roster sync  (#83)
+// ---------------------------------------------------------------------------
+
+/** Minimal member info needed for roster generation. */
+export interface RosterMember {
+  name: string;
+  role: string;
+}
+
+const ROSTER_START = '<!-- SQUAD:ROSTER_START -->';
+const ROSTER_END = '<!-- SQUAD:ROSTER_END -->';
+
+/**
+ * Build a markdown roster block from a list of team members.
+ *
+ * The block is wrapped in HTML comment markers so it can be located
+ * and replaced on subsequent syncs.
+ */
+export function buildRosterBlock(members: readonly RosterMember[]): string {
+  const lines: string[] = [
+    ROSTER_START,
+    '### Current Team Roster',
+    '',
+    '| Name | Role | Charter |',
+    '|------|------|---------|',
+  ];
+  for (const m of members) {
+    const nameLower = m.name.toLowerCase();
+    lines.push(
+      `| ${m.name} | ${m.role} | \`.squad/agents/${nameLower}/charter.md\` |`,
+    );
+  }
+  lines.push(ROSTER_END);
+  return lines.join('\n');
+}
+
+/**
+ * Insert or replace the team roster block inside an agent doc.
+ *
+ * If the doc already contains `<!-- SQUAD:ROSTER_START -->` …
+ * `<!-- SQUAD:ROSTER_END -->` markers, the content between them is
+ * replaced.  Otherwise the roster is inserted before the first `---`
+ * horizontal rule (which separates the header from mode sections in
+ * the standard template), or appended at the end as a fallback.
+ *
+ * @param docContent - Current markdown content of the agent doc
+ * @param members    - Team members to render
+ * @returns Updated markdown with the roster block
+ */
+export function syncRosterToAgentDoc(
+  docContent: string,
+  members: readonly RosterMember[],
+): string {
+  const rosterBlock = buildRosterBlock(members);
+
+  const startIdx = docContent.indexOf(ROSTER_START);
+  const endIdx = docContent.indexOf(ROSTER_END);
+
+  // Guard: orphaned marker (only one present) or reversed markers
+  if (
+    (startIdx !== -1) !== (endIdx !== -1) ||
+    (startIdx !== -1 && endIdx !== -1 && startIdx >= endIdx)
+  ) {
+    console.warn(
+      '[doc-sync] Roster markers are missing, orphaned, or reversed — skipping replacement to avoid corruption',
+    );
+    return docContent;
+  }
+
+  if (startIdx !== -1 && endIdx !== -1) {
+    return (
+      docContent.slice(0, startIdx) +
+      rosterBlock +
+      docContent.slice(endIdx + ROSTER_END.length)
+    );
+  }
+
+  // No markers yet — insert before the first horizontal rule.
+  // Skip YAML frontmatter if present (doc starts with ---).
+  const normalized = docContent.replace(/\r\n/g, '\n');
+  let searchFrom = 0;
+  if (normalized.startsWith('---\n') || normalized.startsWith('---\r\n')) {
+    // Skip past the closing frontmatter delimiter
+    const fmClose = normalized.indexOf('\n---\n', 4);
+    if (fmClose !== -1) {
+      searchFrom = fmClose + 4; // past the closing ---
+    }
+  }
+
+  const hrIdx = normalized.indexOf('\n---\n', searchFrom);
+  if (hrIdx !== -1) {
+    // Use original content but insert at the found position
+    const insertPos = docContent.indexOf('---', searchFrom > 0 ? searchFrom : 1);
+    if (insertPos !== -1) {
+      return (
+        docContent.slice(0, insertPos) +
+        '\n' +
+        rosterBlock +
+        '\n\n' +
+        docContent.slice(insertPos)
+      );
+    }
+  }
+
+  // Fallback: append
+  return docContent.trimEnd() + '\n\n' + rosterBlock + '\n';
+}
 
 /**
  * A single mismatch between the agent doc and the typed config.

--- a/test/agent-doc.test.ts
+++ b/test/agent-doc.test.ts
@@ -11,7 +11,10 @@ import {
   syncDocToConfig,
   syncConfigToDoc,
   detectDrift,
+  buildRosterBlock,
+  syncRosterToAgentDoc,
   type DriftReport,
+  type RosterMember,
 } from '@bradygaster/squad-sdk/config';
 import { defineConfig, type SquadConfig } from '@bradygaster/squad-sdk/config';
 
@@ -392,5 +395,227 @@ describe('detectDrift', () => {
     const config = makeConfig();
     const report = detectDrift(doc, config);
     expect(report.inSync).toBe(true);
+  });
+});
+
+// ============================================================================
+// buildRosterBlock  (#83)
+// ============================================================================
+
+describe('buildRosterBlock', () => {
+  const members: RosterMember[] = [
+    { name: 'Control', role: 'TypeScript Engineer' },
+    { name: 'Eecom', role: 'Runtime Engineer' },
+    { name: 'Scribe', role: 'Session Logger' },
+  ];
+
+  it('should produce a markdown table with correct headers', () => {
+    const block = buildRosterBlock(members);
+    expect(block).toContain('| Name | Role | Charter |');
+    expect(block).toContain('|------|------|---------|');
+  });
+
+  it('should include all members with charter paths', () => {
+    const block = buildRosterBlock(members);
+    expect(block).toContain('| Control | TypeScript Engineer | `.squad/agents/control/charter.md` |');
+    expect(block).toContain('| Eecom | Runtime Engineer | `.squad/agents/eecom/charter.md` |');
+    expect(block).toContain('| Scribe | Session Logger | `.squad/agents/scribe/charter.md` |');
+  });
+
+  it('should wrap output in roster markers', () => {
+    const block = buildRosterBlock(members);
+    expect(block).toMatch(/^<!-- SQUAD:ROSTER_START -->/);
+    expect(block).toMatch(/<!-- SQUAD:ROSTER_END -->$/);
+  });
+
+  it('should contain a heading', () => {
+    const block = buildRosterBlock(members);
+    expect(block).toContain('### Current Team Roster');
+  });
+
+  it('should handle an empty members list', () => {
+    const block = buildRosterBlock([]);
+    expect(block).toContain('<!-- SQUAD:ROSTER_START -->');
+    expect(block).toContain('<!-- SQUAD:ROSTER_END -->');
+    expect(block).toContain('| Name | Role | Charter |');
+  });
+});
+
+// ============================================================================
+// syncRosterToAgentDoc  (#83)
+// ============================================================================
+
+describe('syncRosterToAgentDoc', () => {
+  const members: RosterMember[] = [
+    { name: 'Alpha', role: 'Lead' },
+    { name: 'Beta', role: 'Dev' },
+  ];
+
+  it('should replace content between existing markers', () => {
+    const doc = [
+      '# Squad',
+      '',
+      '<!-- SQUAD:ROSTER_START -->',
+      '_old roster_',
+      '<!-- SQUAD:ROSTER_END -->',
+      '',
+      '---',
+      '',
+      '## Team Mode',
+    ].join('\n');
+
+    const result = syncRosterToAgentDoc(doc, members);
+    expect(result).toContain('| Alpha | Lead |');
+    expect(result).toContain('| Beta | Dev |');
+    expect(result).not.toContain('_old roster_');
+    expect(result).toContain('## Team Mode');
+  });
+
+  it('should insert before first --- when no markers exist', () => {
+    const doc = [
+      '# Squad',
+      '',
+      'Some preamble',
+      '',
+      '---',
+      '',
+      '## Init Mode',
+    ].join('\n');
+
+    const result = syncRosterToAgentDoc(doc, members);
+    expect(result).toContain('| Alpha | Lead |');
+    expect(result).toContain('<!-- SQUAD:ROSTER_START -->');
+    // Roster should appear before the ---
+    const rosterIdx = result.indexOf('<!-- SQUAD:ROSTER_START -->');
+    const hrIdx = result.indexOf('\n---\n');
+    expect(rosterIdx).toBeLessThan(hrIdx);
+    expect(result).toContain('## Init Mode');
+  });
+
+  it('should append if no markers and no --- exist', () => {
+    const doc = '# Squad\n\nJust a heading.';
+    const result = syncRosterToAgentDoc(doc, members);
+    expect(result).toContain('| Alpha | Lead |');
+    expect(result).toContain('<!-- SQUAD:ROSTER_END -->');
+  });
+
+  it('should not duplicate markers on repeated syncs', () => {
+    const doc = [
+      '# Squad',
+      '',
+      '<!-- SQUAD:ROSTER_START -->',
+      '_placeholder_',
+      '<!-- SQUAD:ROSTER_END -->',
+      '',
+      '---',
+    ].join('\n');
+
+    const first = syncRosterToAgentDoc(doc, members);
+    const second = syncRosterToAgentDoc(first, [
+      ...members,
+      { name: 'Gamma', role: 'QA' },
+    ]);
+
+    const startCount = (second.match(/<!-- SQUAD:ROSTER_START -->/g) ?? []).length;
+    const endCount = (second.match(/<!-- SQUAD:ROSTER_END -->/g) ?? []).length;
+    expect(startCount).toBe(1);
+    expect(endCount).toBe(1);
+    expect(second).toContain('| Gamma | QA |');
+    expect(second).toContain('| Alpha | Lead |');
+  });
+
+  it('should preserve content before and after the roster', () => {
+    const doc = [
+      '# Squad',
+      '',
+      '<!-- SQUAD:ROSTER_START -->',
+      '_old_',
+      '<!-- SQUAD:ROSTER_END -->',
+      '',
+      '## Team Mode',
+      '',
+      'Important content here.',
+    ].join('\n');
+
+    const result = syncRosterToAgentDoc(doc, members);
+    expect(result).toContain('# Squad');
+    expect(result).toContain('## Team Mode');
+    expect(result).toContain('Important content here.');
+  });
+
+  it('should skip replacement and return doc unchanged when markers are reversed', () => {
+    const doc = [
+      '# Squad',
+      '',
+      '<!-- SQUAD:ROSTER_END -->',
+      '_bad roster_',
+      '<!-- SQUAD:ROSTER_START -->',
+      '',
+      '## Team Mode',
+    ].join('\n');
+
+    const result = syncRosterToAgentDoc(doc, members);
+    // Must return the original document unchanged
+    expect(result).toBe(doc);
+  });
+
+  it('should skip replacement when only the start marker is present (orphaned)', () => {
+    const doc = [
+      '# Squad',
+      '',
+      '<!-- SQUAD:ROSTER_START -->',
+      '_orphaned_',
+      '',
+      '## Team Mode',
+    ].join('\n');
+
+    const result = syncRosterToAgentDoc(doc, members);
+    expect(result).toBe(doc);
+  });
+
+  it('should skip replacement when only the end marker is present (orphaned)', () => {
+    const doc = [
+      '# Squad',
+      '',
+      '_orphaned_',
+      '<!-- SQUAD:ROSTER_END -->',
+      '',
+      '## Team Mode',
+    ].join('\n');
+
+    const result = syncRosterToAgentDoc(doc, members);
+    expect(result).toBe(doc);
+  });
+
+  it('does not insert roster inside YAML frontmatter', () => {
+    const doc = [
+      '---',
+      'name: Squad',
+      'description: "Your AI team"',
+      '---',
+      '',
+      '# Squad Coordinator',
+      '',
+      '---',
+      '',
+      '## Init Mode',
+    ].join('\n');
+
+    const result = syncRosterToAgentDoc(doc, members);
+    // Roster should NOT appear between the frontmatter delimiters
+    const frontmatterEnd = result.indexOf('---', result.indexOf('---') + 3);
+    const rosterPos = result.indexOf('<!-- SQUAD:ROSTER_START -->');
+    expect(rosterPos).toBeGreaterThan(frontmatterEnd);
+    expect(result).toContain('| Alpha |');
+  });
+
+  it('handles CRLF line endings', () => {
+    const doc = '---\r\nname: Squad\r\n---\r\n\r\n# Header\r\n\r\n---\r\n\r\n## Section\r\n';
+
+    const result = syncRosterToAgentDoc(doc, members);
+    expect(result).toContain('| Alpha |');
+    // Roster should be before the section separator, not inside frontmatter
+    const rosterPos = result.indexOf('<!-- SQUAD:ROSTER_START -->');
+    expect(rosterPos).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

When agents are added to team.md via `squad cast`, the roster in `.github/agents/squad.agent.md` was never updated, causing invisible agents and stale routing.

## Changes

- **`doc-sync.ts`** (SDK): Added `buildRosterBlock()` and `syncRosterToAgentDoc()` functions that generate and inject a roster markdown table between `<!-- SQUAD:ROSTER_START -->` / `<!-- SQUAD:ROSTER_END -->` comment markers
- **`cast.ts`** (CLI): After `createTeam()` updates team.md, it now also syncs the roster into squad.agent.md
- **`squad.agent.md`** (template): Added roster comment markers so the sync has a clean insertion/replacement point
- **`agent-doc.test.ts`**: Added 11 tests covering roster block generation, marker replacement, backward-compatible insertion, idempotent re-syncing, and content preservation

## How it works

1. When `createTeam()` finishes creating/updating team.md, it checks if `.github/agents/squad.agent.md` exists
2. If so, it reads the file and calls `syncRosterToAgentDoc()` with the current member list
3. The function replaces the content between `SQUAD:ROSTER` markers (or inserts before the first `---` for backward compatibility)
4. The updated file is written back

Closes #83